### PR TITLE
Bugfix: allow animated QR on first load

### DIFF
--- a/index.html
+++ b/index.html
@@ -473,7 +473,7 @@
   <script src="/js/bbqr.iife.js"
     integrity="sha384-py0pfboCEsLaalXCe3+epRWqxe3xATD5fChs9v/NVoBMzfy6mB3W9zk6iRMM40ML"></script>
   <script src="/js/main.js"
-    integrity="sha384-wzwXyoueSp6Ty5tzrGflVFD/88UpyGkOIHbhaIHjKFLo8ai6QkJz6dvVp4SRUV8x"></script>
+    integrity="sha384-yexOitCmb4+mNw1+IzuN+Urb2OkxONJ9P3pvbqVeOeemctvDQlVS+8I+Co4RE1kK"></script>
 </body>
 
 </html>


### PR DESCRIPTION
- If the data doesn't fit on a single QR code, render animated version on first page load (previously, an error message was displayed)
- Keep track of the minimum number of QR codes required and disable "Less" and "No animation" buttons if currently at that count